### PR TITLE
Fix quoting in extract function

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -220,23 +220,24 @@ mcd() {
 
 # Extract common file formats
 extract() {
-    if [ -f $1 ] ; then
-        case $1 in
-            *.tar.bz2)   tar xjf $1     ;;
-            *.tar.gz)    tar xzf $1     ;;
-            *.bz2)       bunzip2 $1     ;;
-            *.rar)       unrar e $1     ;;
-            *.gz)        gunzip $1      ;;
-            *.tar)       tar xf $1      ;;
-            *.tbz2)      tar xjf $1     ;;
-            *.tgz)       tar xzf $1     ;;
-            *.zip)       unzip $1       ;;
-            *.Z)         uncompress $1  ;;
-            *.7z)        7z x $1        ;;
-            *)           echo "'$1' cannot be extracted via extract()" ;;
+    local file="$1"
+    if [ -f "$file" ]; then
+        case "$file" in
+            *.tar.bz2)   tar xjf "$file"     ;;
+            *.tar.gz)    tar xzf "$file"     ;;
+            *.bz2)       bunzip2 "$file"     ;;
+            *.rar)       unrar e "$file"     ;;
+            *.gz)        gunzip "$file"      ;;
+            *.tar)       tar xf "$file"      ;;
+            *.tbz2)      tar xjf "$file"     ;;
+            *.tgz)       tar xzf "$file"     ;;
+            *.zip)       unzip "$file"       ;;
+            *.Z)         uncompress "$file"  ;;
+            *.7z)        7z x "$file"        ;;
+            *)           echo "'$file' cannot be extracted via extract()" ;;
         esac
     else
-        echo "'$1' is not a valid file"
+        echo "'$file' is not a valid file"
     fi
 }
 


### PR DESCRIPTION
## Summary
- improve `extract` function in `.zshrc` by quoting filename

## Testing
- `shellcheck install.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d82d2ecd0832d85ffd704e225e5e3